### PR TITLE
Opera rtc updates

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,10 +10,12 @@ dependencies:
   - gsutil
   - h5py
   - hyp3_sdk
+  - ipython
   - ipywidgets
   - jupyterlab
   - kernda
   - numpy
+  - nodejs
   - opencv
   - pandas
   - python=3.9
@@ -21,3 +23,4 @@ dependencies:
   - requests
   - s3fs
   - wget
+  - xarray

--- a/stacks/2-Opera_rtc.ipynb
+++ b/stacks/2-Opera_rtc.ipynb
@@ -1,0 +1,489 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OPERA-RTC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import rasterio\n",
+    "import xarray as xr\n",
+    "import asf_search as asf\n",
+    "\n",
+    "#aws-related imports\n",
+    "from getpass import getpass\n",
+    "import json\n",
+    "import urllib.request\n",
+    "\n",
+    "from vegmapper import s1\n",
+    "from vegmapper import pathurl\n",
+    "\n",
+    "plt.rcParams['font.size'] = 18\n",
+    "plt.rcParams['figure.figsize'] = [16, 12]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## User Inputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Site name\n",
+    "sitename = 'ucayali'\n",
+    "\n",
+    "# Project directory (local path or cloud bucket URL)\n",
+    "proj_dir = '.'\n",
+    "\n",
+    "# AOI file\n",
+    "aoifile = f'{proj_dir}/ucayali_boundary.geojson'\n",
+    "\n",
+    "# Reference tiles\n",
+    "tiles = f'{proj_dir}/{sitename}_tiles.geojson'\n",
+    "\n",
+    "# Start and end dates of interest\n",
+    "start_date = '2024-01-01' # june-sep measure the time it take to average for a burst first for a burst and later for ucayali \n",
+    "end_date = '2024-04-30'\n",
+    "\n",
+    "# Sentinel-1 paltform S1A or S1B, S1 for both\n",
+    "platform = 'S1'\n",
+    "\n",
+    "# RTC directory\n",
+    "rtc_dir = f'{proj_dir}/opera_rtc'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. [Granule Search](#1.-Granule-Search)\n",
+    "2. [Radiometric Terrain Correction (RTC)](#2.-Radiometric-Terrain-Correction-(RTC))\n",
+    "3. [Post-Processing](#3.-Post-Processing)\n",
+    "    - [Get RTC products](#Get-RTC-products)\n",
+    "    - [Build VRTs](#Build-VRTs)\n",
+    "    - [Calculate temporal mean](#Calculate-temporal-mean)\n",
+    "    - [Remove edges](#Remove-edges)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot AOI\n",
+    "gdf_aoi = gpd.read_file(aoifile)\n",
+    "gdf_aoi.plot(figsize=(10, 10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [],
+    "toc-hr-collapsed": true
+   },
+   "source": [
+    "## 1. Granule Search\n",
+    "\n",
+    "ASF DAAC uses *granules* and *scenes* interchangeably to refer to a Sentinel-1 product temporally and geographically, whereas *frames* are used to refer to the geolocation only for a Sentinel-1 product. The naming convention for a Sentinel-1 granule can be found [here](https://asf.alaska.edu/data-sets/sar-data-sets/sentinel-1/sentinel-1-data-and-imagery/). Each *frame* can be uniquely identified by a pair of *path* and *frame* numbers. In this section, we will search for Sentinel-1 granules that intersect with AOI and were acquired between the start and end dates.\n",
+    "\n",
+    "### `s1.search_granules`\n",
+    "\n",
+    "```\n",
+    "s1.search_granules(sitename, aoifile, start_date, end_date, skim=True, **search_opts)\n",
+    "```\n",
+    "\n",
+    "Paremeters:\n",
+    "\n",
+    "|Paremeters|Description|Required|Default|\n",
+    "|----|----|----|----|\n",
+    "|sitename|Site name|Yes||\n",
+    "|aoifile|AOI file in vector-based spatial data format (shapefile, GeoJSON, ...)|Yes||\n",
+    "|start_date|Start date (YYYY-MM-DD)|Yes||\n",
+    "|end_date|End date (YYYY-MM-DD)|Yes||\n",
+    "|skim|Skim the search results so only the frames that just cover the AOI are retained|No|True|\n",
+    "|search_opts|Search options for ASF Python module (asf_search). See [here](https://docs.asf.alaska.edu/asf_search/searching/).|No|True|\n",
+    "\n",
+    "Returns:\n",
+    "\n",
+    "|Returns|Description|\n",
+    "|----|----|\n",
+    "|gdf_granules|A GeoDataFrame containing all searched granules along with their detailed properties|\n",
+    "|gdf_frames|A GeoDataFrame of `gdf_granules` grouped by frames.|"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Here we search for Sentinel-1 OPERA-RTC products acquired with Interferometric Wide (IW) beam mode and both VV and VH polarizations.\n",
+    "search_opts = {\n",
+    "    'dataset': asf.DATASET.OPERA_S1\n",
+    "}\n",
+    "gdf_granules, gdf_frames = s1.search_granules(sitename, aoifile, start_date, end_date, skim=True, **search_opts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf_granules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf_frames"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Granules found over study area "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read in tiles\n",
+    "gdf_tiles = gpd.read_file(tiles).to_crs(epsg=4326)\n",
+    "\n",
+    "# Plot search results\n",
+    "ax = gdf_aoi.plot(figsize=(10, 10))\n",
+    "gdf_granules.boundary.plot(ax=ax, color='red')\n",
+    "gdf_tiles.boundary.plot(ax=ax, color='black')\n",
+    "if (gdf_tiles['mask'] == 0).any():\n",
+    "    ax = gdf_tiles[gdf_tiles['mask'] == 0].plot(ax=ax, color='gray')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Burst count overview"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate burst summary geodataframe and include the flightpath\n",
+    "# Get RTC burst id\n",
+    "gdf_granules['burst_id'] = gdf_granules['fileID'].str[:31]\n",
+    "\n",
+    "# Group by burst id and count number of bursts per burst_id\n",
+    "burst_counts = gdf_granules.groupby('burst_id').size().reset_index(name='count')\n",
+    "\n",
+    "# Group by burst id and aggregate the geometries\n",
+    "grouped_bursts = gdf_granules.groupby('burst_id').agg({\n",
+    "    'geometry': lambda x: x.unary_union,\n",
+    "    'pathNumber': lambda x: x.mode() if x.mode().size > 0 else x.iloc[0]\n",
+    "})\n",
+    "\n",
+    "# Reset index to convert the resulting Series to DataFrame\n",
+    "grouped_bursts = grouped_bursts.reset_index()\n",
+    "\n",
+    "# Merge the grouped geometries and counts back to fileID_grouped_counts\n",
+    "burst_summary = pd.merge(burst_counts, grouped_bursts, on='burst_id', how='left')\n",
+    "\n",
+    "# Convert the DataFrame to a GeoDataFrame\n",
+    "burst_summary_gdf = gpd.GeoDataFrame(burst_summary, geometry='geometry')\n",
+    "\n",
+    "burst_summary_gdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plotting acquisition summary\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "plt.bar(burst_summary_gdf.index, burst_summary_gdf['count'])\n",
+    "plt.xlabel('Burst index number (grouped by burst ID)')\n",
+    "plt.ylabel('Acquisitions per burst')\n",
+    "plt.title('Burst acquisition summary')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get burst summary by count\n",
+    "count_list = burst_summary_gdf['count'].unique()\n",
+    "\n",
+    "# Filter the GeoDataFrame to extract rows where count is equal to the indicated value\n",
+    "def filter_count_gdf(in_df, value):\n",
+    "    filtered_gdf = in_df[in_df['count'] == value]\n",
+    "    \n",
+    "    return filtered_gdf \n",
+    "\n",
+    "# extract geometries to use in plot\n",
+    "burst_count_gdfs = []\n",
+    "for count in count_list:\n",
+    "    burst_count_gdfs.append(gpd.GeoDataFrame((filter_count_gdf(burst_summary_gdf, count)), geometry='geometry'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot search results\n",
+    "cmap = plt.cm.get_cmap('Set2')\n",
+    "ax = gdf_aoi.plot(figsize=(10, 10))\n",
+    "for i, count_gdf in enumerate(burst_count_gdfs):\n",
+    "    count_gdf.boundary.plot(ax=ax, color=cmap(i))\n",
+    "gdf_tiles.boundary.plot(ax=ax, color='black')\n",
+    "if (gdf_tiles['mask'] == 0).any():\n",
+    "    ax = gdf_tiles[gdf_tiles['mask'] == 0].plot(ax=ax, color='gray')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Access RTC data and form temporal average\n",
+    "- The following cells will generate temporary credentials to access the ASF data bucket. \n",
+    "- This will allow us to retrive the desired OPERA-RTC products.\n",
+    "- A free Earthdata login account is required.\n",
+    "-  Go to the link below and create one if you haven't done that yet:\n",
+    "    -  [Create Earthdata account](https://www.earthdata.nasa.gov/eosdis/science-system-description/eosdis-components/earthdata-login)\n",
+    "-  Once your account, login to Earthdata using your credentials.\n",
+    "-  Now we should generate a Bearer Token to access the data bucket following th einstructions below.\n",
+    "    - [Instructions for creating an EDL Bearer Token](https://urs.earthdata.nasa.gov/documentation/for_users/user_token)\n",
+    "-  Copy your Bearer Token and paste it when asked in the cell below.    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Request S3 credencials\n",
+    "**Enter your Earthdata Login Bearer Token**\n",
+    "\n",
+    "The cells below will create temporary credentials to access the OPERA-RTC data. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "token = getpass(\"Enter your EDL Bearer Token\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prefix = \"OPERA_L2_RTC-S1\" "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "event = {\n",
+    "    \"CredentialsEndpoint\": \"https://cumulus.asf.alaska.edu/s3credentials\",\n",
+    "    \"BearerToken\": token,\n",
+    "    \"Bucket\": \"asf-cumulus-prod-opera-products\",\n",
+    "    \"Prefix\": prefix,\n",
+    "    \"StaticPrefix\": f\"{prefix}_STATIC\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get temporary download credentials\n",
+    "tea_url = event[\"CredentialsEndpoint\"]\n",
+    "bearer_token = event[\"BearerToken\"]\n",
+    "req = urllib.request.Request(\n",
+    "    url=tea_url,\n",
+    "    headers={\"Authorization\": f\"Bearer {bearer_token}\"}\n",
+    ")\n",
+    "with urllib.request.urlopen(req) as f:\n",
+    "    creds = json.loads(f.read().decode())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Run RTC load + temp average \n",
+    "In this section we will estimate the temporal mean for each available burst.\n",
+    "  \n",
+    "**Required inputs:**\n",
+    "- List of burst id's \n",
+    "- Geodataframe with granule data\n",
+    "- Earthdata temporary credentials\n",
+    "\n",
+    "`Outputs will be stored as:`\n",
+    "- rtc_tmeans/burstID_tmean_polarization.tif\n",
+    "\n",
+    "`For example:` \n",
+    "- rtc_tmeans/OPERA_L2_RTC-S1_T025-052685-IW1_tmean_VV.tif"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a list of the available burstID to loop over their available data\n",
+    "burst_id_list = burst_summary_gdf['burst_id'].unique().tolist()\n",
+    "\n",
+    "# Create temporal mean for all available bursts\n",
+    "# This may take few minutes. ~20 mins for 119 bursts\n",
+    "s1.run_rtc_temp_mean(burst_id_list, gdf_granules, creds, event)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Display a sample"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Display a sample temporal mean\n",
+    "with rasterio.open(f'./rtc_tmeans/{burst_id_list[0]}_tmean_VV.tif') as dset:\n",
+    "    VV1 = dset.read(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(VV1, vmin=0, vmax=0.5, cmap='Greys')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Create VRT tiles\n",
+    "In this section we will generate virtual raster tiles using the predefined reference tiles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First map the burst to tiles\n",
+    "burst_tile_gdf = s1.map_burst2tile(tiles, burst_summary_gdf)\n",
+    "\n",
+    "# use the table above to run the main flow\n",
+    "s1.build_opera_vrt(burst_tile_gdf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Display a sample tile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with rasterio.open('./rtc_tmeans/tile_vrts/tile_h1_v1_VV.vrt') as dset:\n",
+    "    VV = dset.read(1)\n",
+    "VV[VV == 0] = np.nan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot VV of tile h1v1\n",
+    "plt.imshow(VV, vmin=0, vmax=0.5, cmap='Greys')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  },
+  "toc-autonumbering": false,
+  "toc-showcode": false,
+  "toc-showmarkdowntxt": false,
+  "toc-showtags": false
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/vegmapper/__init__.py
+++ b/vegmapper/__init__.py
@@ -1,13 +1,13 @@
-#from .core import filter
-#from .core.build_condensed_stack import build_condensed_stack
-#from .core.build_stack import build_stack
-#from .core.prep_tiles import prep_tiles
-#from . import asf
-#from . import alos2
-#from . import gee
-#from . import pathurl
-#from . import s1
-#from . import gedi
+from .core import filter
+from .core.build_condensed_stack import build_condensed_stack
+from .core.build_stack import build_stack
+from .core.prep_tiles import prep_tiles
+from . import asf
+from . import alos2
+from . import gee
+from . import pathurl
+from . import s1
+from . import gedi
 ## from . import stack
 ## from . import utils
 #

--- a/vegmapper/s1/__init__.py
+++ b/vegmapper/s1/__init__.py
@@ -1,3 +1,5 @@
 from .postprocess import get_rtc_products, build_vrt, calc_temporal_mean, remove_edges, warp_to_tiles
 from .search import group_granules, skim_granules, search_granules
 from .hyp3 import batch_to_dict, batch_to_df, submit_rtc_jobs, download_files, copy_files
+from .opera_rtc_process import get_burstid_list, get_dt, get_burst_ts_df, load_burst_ts, xarray_tmean, tmean2tiff, run_rtc_temp_mean
+from .opera_rtc_build_vrt import map_burst2tile, build_opera_vrt, get_epsg

--- a/vegmapper/s1/opera_rtc_build_vrt.py
+++ b/vegmapper/s1/opera_rtc_build_vrt.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+
+import os
+import geopandas as gpd
+import rasterio
+from rasterio.crs import CRS
+import subprocess
+
+def map_burst2tile(reference_tiles, burst_summary_gdf):
+    """
+    This function reads the reference tiles
+    and creates a geodataframe that will be 
+    used to map the burst into their 
+    corresponding tile. 
+    Inputs:
+        reference_tiles - Geojson
+        burst_summary_gdf - Geodataframe
+    
+    """
+    
+    # Load the GeoJSON file into a GeoDataFrame
+    tile_gdf = gpd.read_file(reference_tiles)
+    burst_gdf = burst_summary_gdf.copy()
+    # extract target crs from tiles
+    tile_crs = tile_gdf.crs
+    tile_epsg_number = tile_crs.to_string().split(':')[-1]
+    # set burst crs
+    burst_gdf.set_crs(epsg=4326, inplace=True) # This epsg is hard coded because its expected to be always the same.
+    # Ensure both GeoDataFrames have the same CRS before overlapping
+    tile_gdf = tile_gdf.to_crs(epsg=tile_epsg_number)
+    burst_gdf = burst_gdf.to_crs(epsg=tile_epsg_number)
+    
+    # Perform spatial join to find overlapping geometries
+    overlapping_gdf = gpd.sjoin(burst_gdf, tile_gdf, how="inner", op="intersects")
+    
+    # Group by the index of geojson_gdf to collect overlapping 'names'
+    overlap_dict = overlapping_gdf.groupby('index_right')['burst_id'].apply(list).to_dict()
+    
+    # Add the overlapping names back to the GeoJSON GeoDataFrame
+    tile_gdf['overlapping_bursts'] = tile_gdf.index.map(overlap_dict)
+
+    # Export geodataframe as geojson
+    def join_lists(cell):
+        if isinstance(cell, list):
+            return ','.join(cell)
+        return cell
+
+    gdf2export = tile_gdf.copy()
+    # Convert the list of strings in 'overlapping_names' to a single string
+    gdf2export['overlapping_bursts'] = gdf2export['overlapping_bursts'].apply(join_lists)
+    # Convert geometry to WKT format for CSV export
+    gdf2export['geometry'] = gdf2export['geometry'].apply(lambda x: x.wkt)
+    # Export to CSV
+    gdf2export.to_csv(f"./rtc_tmeans/burst_to_tile_map.csv", index=False)
+
+    return tile_gdf
+
+
+def get_epsg(file_path):
+    with rasterio.open(file_path) as dataset:
+        crs = dataset.crs
+        if crs:
+            return crs.to_epsg()
+        return None
+        
+
+def build_opera_vrt(burst2tile_gdf):
+
+    # directory where all rtc means are located. 
+    rtc_dir = './rtc_tmeans'
+    # output directory
+    out_vrt_dir = f'{rtc_dir}/tile_vrts'
+    
+    # Check if the directory exists, if not, create it
+    if not os.path.exists(out_vrt_dir):
+        os.makedirs(out_vrt_dir)
+    
+    polarizations = ['VV', 'VH']
+    target_crs = burst2tile_gdf.crs.to_string()  # Using reference coordinate from tiles
+    for index, row in burst2tile_gdf.iterrows():
+        if row['mask'] != 0:
+            overlapping_names = row['overlapping_bursts']
+            for pol in polarizations:
+                files_2_merge = [f"{rtc_dir}/{name}_tmean_{pol}.tif" for name in overlapping_names]
+                files_2_merge = [file for file in files_2_merge if os.path.exists(file)]
+                bbox = row['geometry'].bounds  # Get bounding box [minx, miny, maxx, maxy]
+                position_h = row['h']
+                position_v = row['v']
+                output_vrt = f'{out_vrt_dir}/tile_h{str(position_h)}_v{str(position_v)}_{pol}.vrt'
+                output_vrt_mosaic = f'{out_vrt_dir}/mosaic_h{str(position_h)}_v{str(position_v)}_{pol}.vrt'
+                
+                reprojected_files = []
+                target_epsg = CRS.from_string(target_crs).to_epsg()
+                for file in files_2_merge:
+                    file_epsg = get_epsg(file)
+                    if file_epsg != target_epsg:  # Compare EPSG code
+                        reprojected_file = file.replace('.tif', '_reprojected.vrt')
+                        if not os.path.exists(reprojected_file):
+                            warp_command_reproject = [
+                                'gdalwarp', '-q',
+                                '-t_srs', target_crs,
+                                '-r', 'near',
+                                '-dstnodata', 'nan',
+                                '-of', 'VRT',
+                                file, reprojected_file
+                            ]
+                            subprocess.run(warp_command_reproject)
+                        reprojected_files.append(reprojected_file)
+                    else:
+                        reprojected_files.append(file)
+                
+                # Construct gdalbuildvrt command to create mosaic VRT with reprojected files
+                buildvrt_command = ['gdalbuildvrt', '-q', '-srcnodata', 'nan', '-vrtnodata', 'nan', output_vrt_mosaic] + reprojected_files
+                subprocess.run(buildvrt_command)
+    
+                # Construct gdalwarp command for final VRT
+                warp_command = [
+                    'gdalwarp',
+                    '-overwrite',
+                    '-t_srs', target_crs, '-et', '0',  # Target CRS
+                    '-te', str(bbox[0]), str(bbox[1]), str(bbox[2]), str(bbox[3]),  # Target extents
+                    '-srcnodata', 'nan', '-dstnodata', 'nan',
+                    '-r', 'near',
+                    '-co', 'COMPRESS=LZW',
+                    '-of', 'VRT',  # Output format
+                    output_vrt_mosaic,  # Input mosaic VRT
+                    output_vrt,  # Output final VRT
+                ]
+    
+                # Run gdalwarp command
+                print('Running tile')
+                subprocess.run(warp_command)

--- a/vegmapper/s1/opera_rtc_process.py
+++ b/vegmapper/s1/opera_rtc_process.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+
+import os
+import re
+import time
+import numpy as np
+import pandas as pd
+import geopandas as gpd
+import rasterio
+import xarray as xr
+import s3fs
+
+# get all related burst
+def get_burstid_list(burst_name, granule_gdf):
+    """
+    Function to get list of available bursts 
+    for the same ID. 
+    inputs
+    ------
+    burst_name = string.
+    granule_gdf = geodataframe with RTC
+        granules for a specific time and region.
+    
+    returns
+    -------
+    burstid_list = list.
+    """
+    burst_id_df = granule_gdf[granule_gdf['fileID'].str.startswith(burst_name)]
+    burstid_list = sorted(burst_id_df['fileID'].tolist())
+
+    return burstid_list
+
+
+# get timestamp
+def get_dt(opera_id, date_regex):
+    acquisition_time = re.search(date_regex, opera_id)
+    try:
+        return acquisition_time.group(0)
+    except AttributeError:
+        raise Exception(f"Acquisition timestamp not found in scene ID: {opera_id}") 
+
+
+# get burst time series dataframe 
+def get_burst_ts_df(opera_rtc_ids):
+    # date time regular expression definitions
+    acquisition_date_regex = r"(?<=_)\d{8}T\d{6}Z(?=_\d{8}T\d{6})"
+    process_dt_regex = r"(?<=\d{8}T\d{6}Z_)\d{8}T\d{6}Z(?=_S1)"
+    acquisition_dt = pd.to_datetime([get_dt(id, acquisition_date_regex) for id in opera_rtc_ids])
+    process_dt = pd.to_datetime([get_dt(id, process_dt_regex) for id in opera_rtc_ids])
+
+    times_series_df = (pd.DataFrame(data={
+        'OPERA L2-RTC-S1 ID': opera_rtc_ids, 
+        'AcquisitionDateTime': acquisition_dt,
+        'ProcessDateTime': process_dt
+    })
+    .sort_values(by='ProcessDateTime')
+    .drop_duplicates(subset=['AcquisitionDateTime'], keep='last')
+    .drop('ProcessDateTime', axis=1)
+    .sort_values(by='AcquisitionDateTime')
+    .reset_index(drop=True))
+
+    return times_series_df
+
+
+# load array using a burst timeseries dataframe
+def load_burst_ts(burst_ts_df, creds, event):
+    """
+    Inputs
+    ------
+    burst_ts_df = dataframe with burst time series.
+    creds = S3 access key dictionary 
+    """
+    fs = s3fs.S3FileSystem(key=creds['accessKeyId'], secret=creds['secretAccessKey'], token=creds['sessionToken'])
+
+    polarizations = ['VV', 'VH']
+    da_stack = []
+    
+    for t, row in burst_ts_df.iterrows():
+        opera_id = row['OPERA L2-RTC-S1 ID']
+        time = pd.to_datetime(row['AcquisitionDateTime'])
+        polarization_stack = []
+    
+        for polarization in polarizations:
+            filename = f"{opera_id}_{polarization}.tif"
+            object_key = f"OPERA_L2_RTC-S1/{opera_id}/{filename}"
+            s3_path = f"s3://{event['Bucket']}/{object_key}"
+    
+            with fs.open(s3_path, mode='rb') as f:
+                da = xr.open_dataarray(f, engine="rasterio")
+                da = da.expand_dims(time=pd.Index([time], name='time'))
+                polarization_stack.append(da)
+    
+        da_polarized = xr.concat(polarization_stack, dim=pd.Index(polarizations, name='polarization'))
+        da_stack.append(da_polarized)
+    
+    ds = xr.concat(da_stack, dim='time')
+    
+    return ds 
+
+
+# estimate temporal mean
+def xarray_tmean(ds, pol):
+    ts = ds.sel(polarization=pol)
+    temporal_avg = ts.mean(dim='time')
+    epsg_code = 'EPSG:' + str(ds.attrs['BOUNDING_BOX_EPSG_CODE'])
+    
+    return temporal_avg, epsg_code
+
+
+# export to xarray temporal mean to tiff
+def tmean2tiff(temporal_avg, file_output, epsg_code):
+    from rasterio.transform import from_origin
+    # Define the GeoTIFF metadata
+    transform = from_origin(temporal_avg.x.values.min(), temporal_avg.y.values.max(), 
+                            abs(temporal_avg.x.values[1] - temporal_avg.x.values[0]), 
+                            abs(temporal_avg.y.values[1] - temporal_avg.y.values[0]))
+    
+    # Save the temporal mean as a GeoTIFF file
+    with rasterio.open(file_output, 'w', driver='GTiff', 
+                       height=temporal_avg.shape[1], width=temporal_avg.shape[2],
+                       count=temporal_avg.shape[0], dtype=temporal_avg.dtype, crs=epsg_code, transform=transform) as dst:
+        dst.write(temporal_avg.values)
+
+
+# main driver
+def run_rtc_temp_mean(burst_id_list, granule_gdf, creds, event):
+    t_all = time.time() # track processing time
+    
+    out_dir = "./rtc_tmeans"
+    # Check if the directory exists
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+        print(f"Directory {out_dir} created.")
+    
+    for burst in burst_id_list:
+        polarization = ['VV', 'VH']
+        # check if the image already exists, skip it it does
+        check_vv = f"{out_dir}/{burst}_tmean_{polarization[0]}.tif"
+        check_vh = f"{out_dir}/{burst}_tmean_{polarization[1]}.tif"
+        if os.path.exists(check_vv) and os.path.exists(check_vh):
+            print(f"Temporal VV & VH means for burst {burst} exist, skipping to the next")
+            continue
+            
+        burst_ids = get_burstid_list(burst, granule_gdf)
+        if len(burst_ids) < 2:
+            print(f"Only one burst available for ID {burst}, skippin temporal average")
+            continue
+            
+        # create df
+        burst_ts_df = get_burst_ts_df(burst_ids)
+        # load xarray
+        burst_ds = load_burst_ts(burst_ts_df, creds, event)
+        for pol in polarization:
+            # calculate temp mean
+            burst_tmean, epsg_code = xarray_tmean(burst_ds, pol)
+            # export tiff
+            out_tif = f"{out_dir}/{burst}_tmean_{pol}.tif"
+            tmean2tiff(burst_tmean, out_tif, epsg_code)
+    # Track processing time 
+    t_all_elapsed = time.time() - t_all # track processing time
+    hours, rem = divmod(t_all_elapsed, 3600)
+    minutes, seconds = divmod(rem, 60)
+    print("Tiffs generated in  {:0>2}:{:0>2}:{:05.2f} hours:min:secs".format(int(hours),int(minutes),seconds)) # track processing time
+


### PR DESCRIPTION
This PR includes several changes that allow the ingestion and analysis of OPER-RTC directly ingested from ASF's bucket. The jupyter notebook 2-OPERA_RTC will use a predefined polygon (from notebook 1) and a time period to query the data, generate temoral means, save the means as tiffs and then tile them to the ore-defined common tiles. 

Two main scripts where added vegmapper/s1/opera_rtc_build_vrt.py and vegmapper/s1/opera_rtc_process.py. The later one is used to connect to bucket, read RTC data, generate temporal mean for each polarization and store as tiff. The opera_rtc_build_vrt.py script will map the bursts to their respective tile, reproject bursts to a common reference frame (defined by the tiles) and finally create the virtual raster tiles. 

Additionally changes were made to the vegmapper/s1/search.py script to include the OPERA-RTC option. 

Few additions were made to the environment file mainly to include xarray, which is used to generate the temoral means. 
