### PR TITLE
Recovered and improved fixes for process_sample

### DIFF
--- a/calval/process_sample.ipynb
+++ b/calval/process_sample.ipynb
@@ -2,6 +2,16 @@
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/NaiaraSPinto/VegMapper/blob/devel-calval2/calval/process_sample.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "id": "8bebd330",
       "metadata": {
         "id": "8bebd330"
@@ -152,7 +162,8 @@
       "execution_count": null,
       "id": "d0IrPNN97mV-",
       "metadata": {
-        "id": "d0IrPNN97mV-"
+        "id": "d0IrPNN97mV-",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
@@ -250,11 +261,15 @@
         "if len(fs) == 1:\n",
         "    dat = process_csv(fs[0], rename_dict, recode_dict, new_col_names,\n",
         "                      key_col=[\"Point_ID\", \"Clust\", \"email\"])\n",
+        "    # fix to drop duplicate error in CEO\n",
+        "    if dat.duplicated().any():\n",
+        "        print(\"dropping erroneous duplicates\")\n",
+        "        dat.drop_duplicates(inplace=True)\n",
         "    labelers = list(dat[\"email\"].unique())\n",
         "    dats = [dat.query(\"email==@labeler\").drop(columns=\"email\", axis=0)\n",
         "            for labeler in labelers]\n",
         "else:\n",
-        "        # Define a partial function with fixed arguments\n",
+        "    # Define a partial function with fixed arguments\n",
         "    process_csv_partial = partial(process_csv, rename_dict=rename_dict,\n",
         "                                  recode_dict=recode_dict,\n",
         "                                  new_col_names=new_col_names)\n",
@@ -299,33 +314,29 @@
       "outputs": [],
       "source": [
         "# @title (RUN) Agreement mode\n",
-        "# labels = []\n",
         "\n",
-        "# for i in range(1, num_labelers + 1):\n",
-        "#     file_name = os.path.splitext(os.path.basename(fs[i-1]))[0]\n",
-        "#     labels.append(file_name)\n",
-        "combined[['class', 'confidence', 'count']] = combined[columns_to_int]\\\n",
+        "combined[['class', 'confidence', 'count']] = (\n",
+        "    combined[columns_to_int]\n",
         "    .apply(get_mode_occurence, axis=1, result_type='expand')\n",
-        "# combined[['class', 'confidence']] = combined[labels]\\\n",
-        "#     .apply(get_mode_occurence, axis=1, result_type='expand')\n",
+        ")\n",
         "pd.set_option('display.max_rows', None)\n",
-        "#print(combined)\n",
-        "\n",
         "# # we can set the mode to -9999 if there is no agreement\n",
-        "# #(mode_freq = 1/num_labelers)\n",
-        "combined.loc[combined['confidence'] <= 1/num_labelers, 'class'] = -9999\n",
-        "combined = combined.drop(combined[combined['class'] == -9999].index)\n",
+        "# # (mode_freq = 1/num_labelers)\n",
+        "combined.loc[combined['confidence'] <= 1 / combined['count'], 'class'] = -9999\n",
+        "unusable = combined[(combined['class'] == -9999) | (combined['class'] == 2)]\n",
+        "# combined.loc[combined['confidence'] <= 1/num_labelers, 'class'] = -9999\n",
+        "# combined = combined.drop(combined[combined['class'] == -9999].index)\n",
         "combined_shp = list(combined.shape)\n",
         "print(f\"Combined project has {combined_shp[0]} rows, {combined_shp[1]} columns\")\n",
+        "if len(unusable) > 0:\n",
+        "    print(f\"{len(unusable)} observations are unusable because they lack \" \\\n",
+        "          \"labeler consensus or most labellers chose 'unsure'\")\n",
         "\n",
-        "# columns_to_int = ['ceo-survey-user1', 'ceo-survey-user2', 'ceo-survey-user3',\\\n",
-        "#                   'class']\n",
         "columns_to_int2 = columns_to_int\n",
         "columns_to_int2.append(\"class\")\n",
-        "combined[columns_to_int2] = combined[columns_to_int2]\\\n",
-        "    .apply(lambda x: x.fillna(-99).astype(int))\n",
-        "combined_pl2 = combined.drop(columns=['Clust'])\n",
-        "combined_pl2.head()"
+        "combined[columns_to_int2] = (combined[columns_to_int2]\n",
+        "                             .apply(lambda x: x.fillna(-99).astype(int)))\n",
+        "display(combined.drop(columns=['Clust']).head())"
       ]
     },
     {
@@ -367,7 +378,15 @@
         "\n",
         "The splits are confined to the usable sample, which is defined as samples not falling into the unsure class and those where there was modal agreement on the class. The resulting splits are denoted in a column called `usage`.\n",
         "\n",
-        "Values of \"unusable\" in the `usage` column indicate observations that were not usable because of their low agreement or classified as unsure.  They are included here for completeness, and in case they help with evaluation\n"
+        "Values of \"unusable\" in the `usage` column indicate observations that were not usable because of their low agreement or classified as unsure.  They are included here for completeness, and in case they help with evaluation\n",
+        "\n",
+        "Note, you should aim to have a suitable number of map reference / test samples in your target class of interest. Choosing this sample size can vary depending on several factors:\n",
+        "\n",
+        "- Whether your objective is to maximize the precision of accuracy or of class areas estimated from the map;\n",
+        "- How accurate the user's or producer's accuracy of the map is;\n",
+        "- What proportion the class of interest represents of the total map.\n",
+        "\n",
+        "[Stehman and Wagner (2024)](https://www.sciencedirect.com/science/article/abs/pii/S0034425723004327?via%3Dihub) provide optimal reference sample size estimates based on these values, but we recommend that you have **at least 30 map reference/test samples** for your class of interest (class 1). To ensure this, you can check the resulting allocations (counts) per class below, and, if necessary, re-run with splitting with different proportions until you get the desired map reference/test size. For example, if you started with splits of 0.7 (train), 0.15 (validation), 0.15 (map reference/test), try 0.7, 0.1, 0.2, or 0.6, 0.1, 0.3.\n"
       ]
     },
     {
@@ -404,23 +423,35 @@
         "\n",
         "seed = 999\n",
         "\n",
-        "n_samples = len(combined)\n",
+        "trainvalref = combined.drop(unusable.index).reset_index(drop=True)\n",
+        "n_samples = len(trainvalref)\n",
         "n_train = int(n_samples * train_split)\n",
         "n_val = int(n_samples * validation_split)\n",
         "n_test = n_samples - n_train - n_val\n",
         "\n",
-        "train = combined.sample(n_train, random_state=seed)\n",
-        "remaining = combined.drop(train.index)\n",
+        "train = trainvalref.sample(n_train, random_state=seed)\n",
+        "remaining = trainvalref.drop(train.index)\n",
         "val = remaining.sample(n_val, random_state=seed)\n",
         "ref = remaining.drop(val.index)\n",
         "\n",
         "out = (\n",
-        "    pd.concat([train.assign(usage=\"train\"), val.assign(usage=\"validate\"),\n",
-        "               ref.assign(usage=\"map_reference/test\")])\n",
+        "    pd.concat([train.assign(usage=\"train\"),\n",
+        "               val.assign(usage=\"validate\"),\n",
+        "               ref.assign(usage=\"map_reference/test\"),\n",
+        "               unusable.assign(usage=\"unusable\")])\n",
         "    .sort_values(by=\"Point_ID\")\n",
         "    .reset_index(drop=True)\n",
         ")\n",
-        "out.drop(columns=['Clust']).head()"
+        "display(out.drop(columns=['Clust']).head(n=3))\n",
+        "\n",
+        "# Group by 'class' and 'usage' and get the value counts\n",
+        "samples_by_group = (out.groupby(['class', 'usage'])\n",
+        "                    .size()\n",
+        "                    .reset_index(name=\"count\"))\n",
+        "\n",
+        "# Display the result\n",
+        "print(\"\\nCounts by class and usage\")\n",
+        "display(samples_by_group)"
       ]
     },
     {
@@ -495,7 +526,7 @@
   "metadata": {
     "colab": {
       "provenance": [],
-      "toc_visible": true
+      "include_colab_link": true
     },
     "gpuClass": "standard",
     "kernelspec": {

--- a/calval/process_sample.ipynb
+++ b/calval/process_sample.ipynb
@@ -2,16 +2,6 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/NaiaraSPinto/VegMapper/blob/devel-calval2/calval/process_sample.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
       "id": "8bebd330",
       "metadata": {
         "id": "8bebd330"


### PR DESCRIPTION
Previous commit of process_sample that added preservation of unusable samples was somehow lost (maybe no PR made from commit to devel-calval branch that was deleted). This PR adds back in that preservation but improves it by:

- conditioning unusable on number of labelers per sample, and also on unsure class
- drops unusable classes from split allocation
- provides guidance for running splits to ensure minimum reference sample size is selected for target class, with reference to Stehman and Wagner (2024)